### PR TITLE
Use generics to provide an transformer based interface for custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pod 'Turnstone'
 ```swift
 import Turnstone
 
-var turnstone = Turnstone()
+var turnstone = NestParameterTurnstone()
 
 turnstone.addRoute("/") { environ, parameters in
   return ("200 OK", [], "Root URI")
@@ -28,7 +28,7 @@ turnstone.addRoute("/tasks/{id}") { environ, parameters in
   return ("200 OK", [], "Task \(id)")
 }
 
-serve("localhost", 8080, turnstone.nest)
+serve("localhost", 8080, turnstone.route)
 ```
 
 ## License

--- a/Turnstone/Turnstone.swift
+++ b/Turnstone/Turnstone.swift
@@ -11,42 +11,87 @@ import Inquiline
 import URITemplate
 
 
-// Simple Nest compatible URI Template Router
-public class Turnstone {
-  public typealias Parameters = [String:String]
-  public typealias Handler = (Environ, Parameters) -> (Response)
+public typealias URI = String
+public typealias URIParameters = [String:String]
+
+// Simple Nest compatible request router
+public class Turnstone<RequestType, ParametersRequestType, ResponseType> {
+  public typealias Handler = ParametersRequestType -> ResponseType
+  public typealias NotFoundHandler = RequestType -> ResponseType
+  public typealias RequestTransform = (RequestType, URIParameters) -> ParametersRequestType
+  public typealias URITransform = RequestType -> URI
+
+  let uriTransform:URITransform
+  let requestTransform:RequestTransform
+  let notFound:NotFoundHandler
 
   var routes = [(URITemplate, Handler)]()
 
-  /// The handler for when a router isn't found
-  public var notFoundHandler:NestApplication = { environ in
-    return ("404 NOT FOUND", [("Content-Type", "text/plain; charset=utf8")], "Page Not Found")
+  public init(uriTransform:URITransform, requestTransform:RequestTransform, notFound:NotFoundHandler) {
+    self.uriTransform = uriTransform
+    self.requestTransform = requestTransform
+    self.notFound = notFound
   }
-
-  public init() {}
 
   /** Add a handler for the given URI Template
   :param: uri A URI Template
   :param: handler The handler for the given URI
   */
-  public func addRoute(uri:String, handler:Handler) {
+  public func addRoute(uri:URI, handler:Handler) {
     routes.append((URITemplate(template: uri), handler))
   }
 
-  public func addNestRoute(uri:String, handler:NestApplication) {
-    routes.append((URITemplate(template: uri), { (environ, parameters) in return handler(environ) }))
-  }
-
-  /// A Nest compatible interface
-  public func nest(environ:Environ) -> Response {
-    if let uri = environ["PATH_INFO"] as? String {
-      for (template, handler) in routes {
-        if let variables = template.extract(uri) {
-          return handler(environ, variables)
-        }
+  public func route(request:RequestType) -> ResponseType {
+    let uri = uriTransform(request)
+    for (template, handler) in routes {
+      if let parameters = template.extract(uri) {
+        let parameterRequest = requestTransform(request, parameters)
+        return handler(parameterRequest)
       }
     }
 
-    return notFoundHandler(environ)
+    return notFound(request)
   }
+}
+
+/// Returns a Nest compatible turnstone
+public func NestTurnstone(notFound:(Environ -> Response)? = nil) -> Turnstone<Environ, Environ, Response> {
+  func uriTransform(environ:Environ) -> URI {
+    return environ["PATH_INFO"] as? String ?? "/"
+  }
+
+  func requestTransform(environ:Environ, parameters:URIParameters) -> (Environ) {
+    return (environ)
+  }
+
+  func defaultNotFound(environ:Environ) -> Response {
+    if let notFound = notFound {
+      return notFound(environ)
+    }
+
+    return ("404 NOT FOUND", [], "Page Not Found")
+  }
+
+  return Turnstone(uriTransform, requestTransform, defaultNotFound)
+}
+
+/// Returns a Nest compatible turnstone exposing the URI Parameters
+public func NestParameterTurnstone(notFound:(Environ -> Response)? = nil) -> Turnstone<Environ, (Environ, URIParameters), Response> {
+  func uriTransform(environ:Environ) -> URI {
+    return environ["PATH_INFO"] as? String ?? "/"
+  }
+
+  func requestTransform(environ:Environ, parameters:URIParameters) -> (Environ, URIParameters) {
+    return (environ, parameters)
+  }
+
+  func defaultNotFound(environ:Environ) -> Response {
+    if let notFound = notFound {
+      return notFound(environ)
+    }
+
+    return ("404 NOT FOUND", [], "Page Not Found")
+  }
+
+  return Turnstone(uriTransform, requestTransform, defaultNotFound)
 }


### PR DESCRIPTION
The idea behind this is that we can use Turnstone with custom transformers making it easy to mix and match Turnstone with Nest-based middleware and web frameworks which might use custom types.

Theoretical example:

``` swift
struct Request {
  let uri:String
  let parameters:[String:String]
}

var turnstone = Turnstone({request in request.uri}, undefined, undefined)

turnstone.addRoute('/questions/{id}') { request in
  let id = request.parameters["id"]
  return Response("Question \(id)")
}

turnstone.route  // takes a "Request" structure and expects a "Response" structure to be returned
```
